### PR TITLE
Fixes and features

### DIFF
--- a/firmware_patching/include/types.h
+++ b/firmware_patching/include/types.h
@@ -7,6 +7,7 @@ typedef unsigned int            dword;
 typedef unsigned char           bool;
 typedef signed char             int8_t;
 typedef unsigned char           uint8_t;
+typedef unsigned char		u8;
 typedef signed short int        int16_t;
 typedef unsigned short int      uint16_t;
 typedef signed int              int32_t;

--- a/firmware_patching/monitor_mode/Makefile
+++ b/firmware_patching/monitor_mode/Makefile
@@ -5,6 +5,8 @@ FUNCTIONS_BIN = $(FUNCTIONS:=.bin)
 all: brcmfmac/brcmfmac.ko brcmfmac43430-sdio.bin
 
 brcmfmac/brcmfmac.ko: check-nexmon-setup-env
+	make -C ../../kernel/ bcm2709_defconfig
+	make -C ../../kernel/
 	make -C ../../kernel/ M=$$PWD/brcmfmac -j2
 
 brcmfmac43430-sdio.bin: patcher.py patch.elf text.bin $(FUNCTIONS_BIN)

--- a/firmware_patching/monitor_mode/brcm.h
+++ b/firmware_patching/monitor_mode/brcm.h
@@ -1,0 +1,3 @@
+#include "../include/types.h"
+#define CHSPEC_CHANNEL(chspec)  ((u8)((chspec) & WL_CHANSPEC_CHAN_MASK))
+#define WL_CHANSPEC_CHAN_MASK           0x00ff

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,3 +1,4 @@
+if [ -d "$(pwd)/buildtools" ]; then
 export CC=$(pwd)/buildtools/gcc-linaro-arm-linux-gnueabihf-raspbian/bin/arm-linux-gnueabihf-
 export CROSS_COMPILE=$(pwd)/buildtools/arm-eabi-4.7/bin/arm-eabi-
 
@@ -8,3 +9,9 @@ export NEXMON_FIRMWARE_PATCHING=$(pwd)/firmware_patching
 export NEXMON_ROOT=$(pwd)
 
 export NEXMON_SETUP_ENV=1
+
+else 
+
+echo "This script should be run at nexmon's root folder!"
+fi
+


### PR DESCRIPTION
Alright, these 3 commits address some problems I had while I compiled the brcmfmac module for the first time:
## Issues
- There are some missing includes: This is solved in 74e903f by adding brcm.h and the u8 definition inside types.h
- Insmod wouldn't load the module: I could read in dmesg "no symbol version for module_layout" and that happened because the kernel needs to be completely built, I just added the function in      62bd78e
## Feature(s)

While I was playing with it, I run the command `source ../../setup_env.sh` while I was at another directory, and as a result, the Cross Compiler wasn't found, so it can just be executed from the root directory   83c2c0d
