### PR TITLE
Add Raspberry Pi compilation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,22 @@ Our software may damage your hardware and may void your hardware’s warranty! Y
 
 ## Steps to create your own firmware patches
 
-This code is supposed to be **cross-compiled** on a x86 hardware. Compiling this code on the Raspberry Pi 3 itself is not supported.
+### Using a x68 based computer
 
 * `source setup_env.sh`
 * for the monitor mode patch: `cd firmware_patching/monitor_mode/`
 * `make`
 * copy the `brcmfmac/brcmfmac.ko` to the `/root/` directory of your Raspberry Pi
 * copy the `brcmfmac43430-sdio.bin` to `/lib/firmware/brcm/` directory of your Raspberry Pi
+
+### Using your Raspberry Pi
+
+* `sudo apt install raspberrypi-kernel-headers `
+* `source setup_env.sh`
+* for the monitor mode patch: `cd firmware_patching/nexmon/`
+* `make rpi3`
+* copy the `brcmfmac/brcmfmac.ko` to the `/root/` directory of your Raspberry Pi
+* download the prebuilt `brcmfmac43430-sdio.bin` from the download page and copy it to `/lib/firmware/brcm/` directory of your Raspberry Pi
 
 ## Caveats
 * ~~Switching channels does not work~~ it works now, but it needs a patch in the kernel, see 8f4b7501dedf72306c471e4962478b8ffe91d7a8

--- a/firmware_patching/nexmon/Makefile
+++ b/firmware_patching/nexmon/Makefile
@@ -15,18 +15,26 @@ FP_CONFIG_BASE=0x5A3A8
 FP_DATA_BASE=0x1000
 FW_FILE_NAME=brcmfmac43430-sdio.bin
 
+ifneq ($(shell uname -m),armv7l)
 CC=../../buildtools/gcc-arm-none-eabi-5_4-2016q2/bin/arm-none-eabi-
-
+endif
 ORIG_FW=../../bootimg_src/firmware/brcmfmac43430-sdio.orig.bin
 
 all: brcmfmac/brcmfmac.ko brcmfmac43430-sdio.bin
+
+rpi3: brcmfmac/brcmfmac.ko
 
 #include ucode_compression_code.mk
 
 brcmfmac/brcmfmac.ko: check-nexmon-setup-env
 #	make -C ../../kernel/ bcm2709_defconfig
 #	make -C ../../kernel/ -j4
+ifneq ($(shell uname -m),armv7l)
 	make -C ../../kernel/ M=$$PWD/brcmfmac -j2
+else
+	make -C /lib/modules/$(shell uname -r)/build M=$$PWD/brcmfmac  -j2
+endif
+
 
 %.o: %.c ../include/*.h
 	$(CC)gcc \

--- a/firmware_patching/nexmon/brcmfmac/Makefile
+++ b/firmware_patching/nexmon/brcmfmac/Makefile
@@ -17,7 +17,7 @@
 
 ccflags-y += \
 	-Idrivers/net/wireless/brcm80211/brcmfmac	\
-	-Idrivers/net/wireless/brcm80211/include
+	-I$(NEXMON_ROOT)/kernel/drivers/net/wireless/brcm80211/include
 
 ccflags-y += -D__CHECK_ENDIAN__
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 OLD_PWD=$(pwd)
+ARCH=`uname -m`
 cd $(dirname ${BASH_SOURCE[0]})
 
-if [ -d "$(pwd)/buildtools" ] && [ -d "$(pwd)/firmware_patching" ]; then
+if [ -d "$(pwd)/buildtools" ] && [ -d "$(pwd)/firmware_patching" ] && [ $ARCH != "armv7l" ]; then
  # Compiler for the NexMon firmware
  export CC=$(pwd)/buildtools/gcc-arm-none-eabi-5_4-2016q2/bin/arm-none-eabi-
  # Compiler for the RPI3 kernel
@@ -13,10 +14,16 @@ if [ -d "$(pwd)/buildtools" ] && [ -d "$(pwd)/firmware_patching" ]; then
 
  export NEXMON_FIRMWARE_PATCHING=$(pwd)/firmware_patching
  export NEXMON_ROOT=$(pwd)
-
  export NEXMON_SETUP_ENV=1
-else
+else if [ $ARCH != "armv7l" ]; then
  echo "One or more required folders are missing!"
+fi
+fi
+
+if [ $ARCH == "armv7l" ]; then
+ echo "Raspberry Pi detected, disabling cross-compilation."
+ export NEXMON_SETUP_ENV=1
+ export NEXMON_ROOT=$(pwd)
 fi
 
 cd "$OLD_PWD"


### PR DESCRIPTION
This is achieved compiling the module against the rpi's kernel, the firmware must be downloaded as a prebuilt file.

In my opinion, this will make it easier for the ones that don't have a GNU/Linux based computer and want to compile it with their rpi.
